### PR TITLE
Fix issue when only uploading a desktop logo

### DIFF
--- a/Magento_Theme/templates/html/header/logo.phtml
+++ b/Magento_Theme/templates/html/header/logo.phtml
@@ -43,7 +43,7 @@ $imgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customLogoUrl : $logoSr
 <div class="order-1 sm:order-2 lg:order-1 w-full pb-2 sm:w-auto sm:pb-0">
     <a
         class="flex items-center justify-center text-xl font-medium tracking-wide text-gray-800
-            no-underline hover:no-underline font-title hidden sm:block"
+            no-underline hover:no-underline font-title <?= $customMobileLogoUrl ? 'hidden sm:block' : '' ?>"
         href="<?= $escaper->escapeUrl($block->getUrl('')) ?>"
         aria-label="<?= $escaper->escapeHtmlAttr(__('Go to Home page')) ?>"
     >


### PR DESCRIPTION
When you had only uploaded a custom desktop image the image would disappear on mobile. This was because the desktop image was always set to hide on mobile but the mobile image would only display if one had actually been set.

Updated the styling to only hide the desktop image if we have a custom mobile one ready to display.