### PR TITLE
Fix issue with customer desktop image overriding default mobile logo

### DIFF
--- a/Magento_Theme/templates/html/header/logo.phtml
+++ b/Magento_Theme/templates/html/header/logo.phtml
@@ -38,18 +38,19 @@ $logoSrc = $logoPathResolver && method_exists($logoPathResolver, 'getLogoSrc')
 $customLogoUrl = $viewModel ? $viewModel->getStoreConfig('bluefinch_build/general/logo') : null;
 $customMobileLogoUrl = $viewModel ? $viewModel->getStoreConfig('bluefinch_build/general/mobile_logo') : null;
 
-$imgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customLogoUrl : $logoSrc;
+$desktopImgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customLogoUrl : $logoSrc;
+$mobileImgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customMobileLogoUrl : $logoSrc;
 ?>
 <div class="order-1 sm:order-2 lg:order-1 w-full pb-2 sm:w-auto sm:pb-0">
     <a
         class="flex items-center justify-center text-xl font-medium tracking-wide text-gray-800
-            no-underline hover:no-underline font-title <?= $customMobileLogoUrl ? 'hidden sm:block' : '' ?>"
+            no-underline hover:no-underline font-title hidden sm:block"
         href="<?= $escaper->escapeUrl($block->getUrl('')) ?>"
         aria-label="<?= $escaper->escapeHtmlAttr(__('Go to Home page')) ?>"
     >
         <img
             class="max-w-[150px] max-h-[75px]"
-            src="<?= $escaper->escapeUrl($imgSrc) ?>"
+            src="<?= $escaper->escapeUrl($desktopImgSrc) ?>"
             alt="<?= $escaper->escapeHtmlAttr($block->getLogoAlt() ? $block->getLogoAlt() : __('Store logo')) ?>"
             <?= $logoWidth && !$customLogoUrl
                 ? 'width="' . $escaper->escapeHtmlAttr($logoWidth) . '"'
@@ -64,7 +65,6 @@ $imgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customLogoUrl : $logoSr
             <?= $escaper->escapeHtml($storeName) ?>
         <?php endif; ?>
     </a>
-    <?php if ($customMobileLogoUrl): ?>
     <a
         class="flex items-center justify-center text-xl font-medium tracking-wide text-gray-800
             no-underline hover:no-underline font-title sm:hidden"
@@ -73,12 +73,11 @@ $imgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customLogoUrl : $logoSr
     >
         <img
             class="max-w-[100px] max-h-[50px]"
-            src="<?= $escaper->escapeUrl($block->getUrl() .'media/' . $customMobileLogoUrl) ?>"
+            src="<?= $escaper->escapeUrl($mobileImgSrc) ?>"
             alt="<?= $escaper->escapeHtmlAttr($block->getLogoAlt() ? $block->getLogoAlt() : __('Store mobile logo')) ?>"
         />
         <?php if (!$logoSrc): ?>
             <?= $escaper->escapeHtml($storeName) ?>
         <?php endif; ?>
     </a>
-    <?php endif; ?>
 </div>


### PR DESCRIPTION
If you had set a custom desktop logo and used the default mobile logo the desktop one would always be displayed. This is because the mobile image was only being displayed if a custom one had been set so the custom desktop one would have always been displayed.

Updated so that the mobile image is always displayed even if it's not a custom image so that it will override the desktop one regardless of whether desktop is custom or not.